### PR TITLE
Fix dropdown hover

### DIFF
--- a/src/styles/scss/custom.scss
+++ b/src/styles/scss/custom.scss
@@ -276,6 +276,17 @@ button.nav-link {
 	height: auto;
 }
 
+.dropdown {
+	padding: 16px;
+	margin: -16px;
+}
+
+.dropdown-menu {
+	position: relative;
+	margin-top: -16px;
+	z-index: 99;
+}
+
 .dropdown:hover > .dropdown-menu {
 	display: block;
 }


### PR DESCRIPTION
Na versão atual, quando passa o mouse em cima dos botões do menu aparece o menu dropdown. Porém a área do hover é muito pequena, causando uma certa dificuldade para acessar o dropdown com o hover. O comportameto atual é observado abaixo: 
![bug_hover](https://user-images.githubusercontent.com/26843282/94879900-efee0d00-0437-11eb-85d9-6ef7ef03f669.gif)

Então, alterei o css para que área do hover fique maior, e mantendo as dimensões do elemento.
Resultado após a correção:
![fixed](https://user-images.githubusercontent.com/26843282/94880017-3cd1e380-0438-11eb-84bb-da70e83a65bf.gif)



